### PR TITLE
Add the possibility to get an empty EventStream without call getEventStream

### DIFF
--- a/lib/eventStore.js
+++ b/lib/eventStore.js
@@ -312,7 +312,7 @@ Store.prototype = {
     // - __streamId:__ id for requested stream (equal to aggregateId)
     getNewEventStream: function(streamId) {
         return new EventStream(self, streamId, null);
-    }
+    },
     
     // __getEventStream:__ loads the eventstream from _revMin_ to _revMax_.
     // 


### PR DESCRIPTION
The only solution to have a new EventStream is to call getEventStream from eventstore. Sometimes we need a new empty EventStream. we can create an empty EventStream outside of eventStore and reference the eventStore but it's cleaner to encapsulate this possibility in the eventStore.

I've create an getNewEventStream function that return an empty eventStream initialized with steamId and current eventStore.
