### PR TITLE
[-] mongodb get all events fix

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -84,6 +84,9 @@ _.extend(Mongo.prototype, {
         self.events = new mongo.Collection(client, options.eventsCollectionName);
         self.events.ensureIndex({ streamId: 1, aggregateId: 1, aggregate: 1, context: 1, commitId: 1, commitStamp: 1, commitSequence: 1 },
           function (err) { if (err) { debug(err); } });
+
+        self.events.ensureIndex({commitStamp: 1, streamRevision: 1, commitSequence: 1},
+          function (err) { if (err) { debug(err); } });
         
         self.snapshots = new mongo.Collection(client, options.snapshotsCollectionName);
         self.snapshots.ensureIndex({ streamId: 1, aggregateId: 1, aggregate: 1, context: 1, commitStamp: 1, revision: 1, version: 1 },


### PR DESCRIPTION
fix error

{ [MongoError: Runner error: Overflow sort stage buffered data usage of 33554600 bytes exceeds internal limit of 33554432 bytes] name: 'MongoError' }
