### PR TITLE
Fix stream revision # after snapshot

### DIFF
--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -251,6 +251,10 @@ _.extend(Eventstore.prototype, {
           if (err) {
             return callback(err);
           }
+
+          if (rev > 0 && stream.lastRevision == -1) {
+            stream.lastRevision = rev - 1;
+          }
           
           callback(null, snap, stream);
         });


### PR DESCRIPTION
In getFromSnapshot if there are no events in the stream after the snapshot, the
returned stream object had a lastRevision of -1 which causes the next event to
be created with a revision number of 0, breaking the event stream. This fix
set's the last revision equal to the snapshot's revision number.