### PR TITLE
mongodb and inmemory performance improvements

### DIFF
--- a/lib/databases/inmemory.js
+++ b/lib/databases/inmemory.js
@@ -10,6 +10,7 @@ function InMemory(options) {
   Store.call(this, options);
   this.store = {};
   this.snapshots = {};
+  this.undispatchedEvents = {};
 }
 
 util.inherits(InMemory, Store);
@@ -56,6 +57,7 @@ _.extend(InMemory.prototype, {
   clear: function (callback) {
     this.store = {};
     this.snapshots = {};
+    this.undispatchedEvents = {};
     if (callback) callback(null);
   },
 
@@ -86,6 +88,11 @@ _.extend(InMemory.prototype, {
     this.store[context][aggregate][aggregateId] = this.store[context][aggregate][aggregateId] || [];
 
     this.store[context][aggregate][aggregateId] = this.store[context][aggregate][aggregateId].concat(events);
+
+    var self = this;
+    _.forEach(events, function(evt) {
+      self.undispatchedEvents[evt.id] = evt;
+    });
 
     callback(null);
   },
@@ -215,31 +222,16 @@ _.extend(InMemory.prototype, {
   },
 
   getUndispatchedEvents: function (callback) {
-    var res = [];
-
-    this.getEvents({}, 0, -1, function (err, evts) {
-      for (var ele in evts) {
-        var evt = evts[ele];
-        if (!evt.dispatched) {
-          res.push(evt);
-        }
-      }
-      callback(null, res);
+    var res = _.map(this.undispatchedEvents, function(value, key) {
+      return value;
     });
+
+    callback(null, res);
   },
 
   setEventToDispatched: function (id, callback) {
-    var res;
-
-    this.getEvents({ id: id }, 0, -1, function (err, evts) {
-      if (evts && evts.length > 0) {
-        res = evts[0];
-      }
-
-      res.dispatched = true;
-
-      callback(null);
-    });
+    delete this.undispatchedEvents[id];
+    callback(null);
   },
 
   addSnapshot: function(snap, callback) {

--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -82,44 +82,13 @@ _.extend(Mongo.prototype, {
         self.client = client;
         
         self.events = new mongo.Collection(client, options.eventsCollectionName);
-        self.events.ensureIndex({ streamId: 1, aggregateId: 1, aggregate: 1, context: 1, commitId: 1, commitStamp: 1, commitSequence: 1, streamRevision: 1 },
+        self.events.ensureIndex({ aggregateId: 1, streamRevision: 1 },
           function (err) { if (err) { debug(err); } });
-
-        self.events.ensureIndex({ aggregateId: 1, aggregate: 1, context: 1 },
-          function (err) { if (err) { debug(err); } });
-
-        self.events.ensureIndex({ aggregateId: 1, aggregate: 1 },
-          function (err) { if (err) { debug(err); } });
-
-        self.events.ensureIndex({ aggregateId: 1 },
-          function (err) { if (err) { debug(err); } });
-
-        self.events.ensureIndex({ streamId: 1 },
-          function (err) { if (err) { debug(err); } });
-
         self.events.ensureIndex({ dispatched: 1 },
           function (err) { if (err) { debug(err); } });
         
-        self.events.ensureIndex({ commitStamp: 1, streamRevision: 1, commitSequence: 1 },
-          function (err) { if (err) { debug(err); } });
-        
         self.snapshots = new mongo.Collection(client, options.snapshotsCollectionName);
-        self.snapshots.ensureIndex({ streamId: 1, aggregateId: 1, aggregate: 1, context: 1, commitStamp: 1, revision: 1, version: 1 },
-          function (err) { if (err) { debug(err); } });
-        
-        self.snapshots.ensureIndex({ revision: -1, version: -1, commitStamp: -1 },
-          function (err) { if (err) { debug(err); } });
-
-        self.snapshots.ensureIndex({ aggregateId: 1, aggregate: 1, context: 1 },
-          function (err) { if (err) { debug(err); } });
-
-        self.snapshots.ensureIndex({ aggregateId: 1, aggregate: 1 },
-          function (err) { if (err) { debug(err); } });
-
-        self.snapshots.ensureIndex({ aggregateId: 1 },
-          function (err) { if (err) { debug(err); } });
-
-        self.snapshots.ensureIndex({ streamId: 1 },
+        self.snapshots.ensureIndex({ aggregateId: 1, revision: -1 },
           function (err) { if (err) { debug(err); } });
 
         self.transactions = new mongo.Collection(client, options.transactionsCollectionName);
@@ -241,10 +210,7 @@ _.extend(Mongo.prototype, {
     }
     
     if (query.aggregateId) {
-      findStatement['$or'] = [
-        { aggregateId: query.aggregateId },
-        { streamId: query.aggregateId } // just for compatability of < 1.0.0
-      ];
+      findStatement.aggregateId = query.aggregateId;
     }
 
     if (limit === -1) {
@@ -262,17 +228,14 @@ _.extend(Mongo.prototype, {
       return;
     }
     
-    var options = { '$gte': revMin, '$lt': revMax };
+    var streamRevOptions = { '$gte': revMin, '$lt': revMax };
     if (revMax == -1) {
-      options = { '$gte': revMin };
+      streamRevOptions = { '$gte': revMin };
     }
 
     var findStatement = {
-      '$or': [
-        { aggregateId: query.aggregateId },
-        { streamId: query.aggregateId } // just for compatability of < 1.0.0
-      ],
-      streamRevision: options
+      aggregateId: query.aggregateId,
+      streamRevision: streamRevOptions
     };
 
     if (query.aggregate) {
@@ -367,10 +330,7 @@ _.extend(Mongo.prototype, {
     }
     
     var findStatement = {
-      '$or': [
-        { aggregateId: query.aggregateId },
-        { streamId: query.aggregateId } // just for compatability of < 1.0.0
-      ]
+      aggregateId: query.aggregateId
     };
 
     if (query.aggregate) {

--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -84,7 +84,7 @@ _.extend(Mongo.prototype, {
         self.events = new mongo.Collection(client, options.eventsCollectionName);
         self.events.ensureIndex({ aggregateId: 1, streamRevision: 1 },
           function (err) { if (err) { debug(err); } });
-        self.events.ensureIndex({ dispatched: 1 },
+        self.events.ensureIndex({ dispatched: 1 }, { sparse: true },
           function (err) { if (err) { debug(err); } });
         
         self.snapshots = new mongo.Collection(client, options.snapshotsCollectionName);
@@ -305,7 +305,7 @@ _.extend(Mongo.prototype, {
   },
 
   setEventToDispatched: function (id, callback) {
-    var updateCommand = { '$set' : { 'dispatched': true } };
+    var updateCommand = { '$unset' : { 'dispatched': null } };
     this.events.update({'_id' : id}, updateCommand, callback);
   },
 

--- a/lib/databases/tingodb.js
+++ b/lib/databases/tingodb.js
@@ -37,44 +37,13 @@ _.extend(Tingo.prototype, {
     //   self.emit('disconnect');
     // });
     this.events = this.db.collection(options.eventsCollectionName + '.tingo');
-    this.events.ensureIndex({ streamId: 1, aggregateId: 1, aggregate: 1, context: 1, commitId: 1, commitStamp: 1, commitSequence: 1, streamRevision: 1 },
+    this.events.ensureIndex({ aggregateId: 1, streamRevision: 1 },
       function (err) { if (err) { debug(err); } });
-
-    this.events.ensureIndex({ aggregateId: 1, aggregate: 1, context: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.events.ensureIndex({ aggregateId: 1, aggregate: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.events.ensureIndex({ aggregateId: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.events.ensureIndex({ streamId: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.events.ensureIndex({ dispatched: 1 },
-      function (err) { if (err) { debug(err); } });
-    
-    this.events.ensureIndex({ commitStamp: 1, streamRevision: 1, commitSequence: 1 },
+    this.events.ensureIndex({ dispatched: 1 }, { sparse: true },
       function (err) { if (err) { debug(err); } });
 
     this.snapshots = this.db.collection(options.snapshotsCollectionName + '.tingo');
-    this.snapshots.ensureIndex({ streamId: 1, aggregateId: 1, aggregate: 1, context: 1, commitStamp: 1, revision: 1, version: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.snapshots.ensureIndex({ revision: -1, version: -1, commitStamp: -1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.snapshots.ensureIndex({ aggregateId: 1, aggregate: 1, context: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.snapshots.ensureIndex({ aggregateId: 1, aggregate: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.snapshots.ensureIndex({ aggregateId: 1 },
-      function (err) { if (err) { debug(err); } });
-
-    this.snapshots.ensureIndex({ streamId: 1 },
+    this.snapshots.ensureIndex({ aggregateId: 1, revision: -1 },
       function (err) { if (err) { debug(err); } });
 
     this.transactions = this.db.collection(options.transactionsCollectionName + '.tingo');
@@ -205,9 +174,9 @@ _.extend(Tingo.prototype, {
       return;
     }
 
-    var options = { '$gte': revMin, '$lt': revMax };
+    var streamRevOptions = { '$gte': revMin, '$lt': revMax };
     if (revMax == -1) {
-      options = { '$gte': revMin };
+      streamRevOptions = { '$gte': revMin };
     }
 
     var findStatement = {
@@ -215,7 +184,7 @@ _.extend(Tingo.prototype, {
         { aggregateId: query.aggregateId },
         { streamId: query.aggregateId } // just for compatability of < 1.0.0
       ],
-      streamRevision: options
+      streamRevision: streamRevOptions
     };
 
     if (query.aggregate) {
@@ -285,7 +254,7 @@ _.extend(Tingo.prototype, {
   },
 
   setEventToDispatched: function (id, callback) {
-    var updateCommand = { '$set' : { 'dispatched': true } };
+    var updateCommand = { '$unset' : { 'dispatched': null } };
     this.events.update({'_id' : id}, updateCommand, callback);
   },
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cradle": ">=0.6.7",
     "expect.js": ">= 0.1.2",
     "mocha": ">= 1.0.1",
-    "mongodb": ">= 0.0.1",
+    "mongodb": ">= 0.0.1 < 2.0.0",
     "redis": ">= 0.10.1",
     "tingodb": ">= 0.0.1",
     "azure-storage": ">= 0.3.0"


### PR DESCRIPTION
**Massive mongodb performance improvements**

Before: very low throughput, bad scalability in number of aggregates and number of events, full CPU load consumed by mongod process due to inefficient event fetching
Now: much improved throughput (> factor 10), good scalability, moderate CPU load

All tests are green (run with mongo 2.0.24 driver).