### PR TITLE
Support authSource authentication option in mongodb

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -103,6 +103,11 @@ _.extend(Mongo.prototype, {
         if (callback) callback(null, self);
       }
 
+      // Authenticate with authSource
+      if (options.authSource && options.username && options.password) {
+        return client.authenticate(options.username, options.password, {authSource: options.authSource}, finish);
+      } else
+
       if (options.username) {
         return client.authenticate(options.username, options.password, finish);
       }


### PR DESCRIPTION
You can add now an authentication database for mongodb by initialising the eventstore:

```
var es = require('eventstore')({
  type: 'mongodb',
  host: 'localhost',                          // optional
  port: 27017,                                // optional
  dbName: 'eventstore',                       // optional
  eventsCollectionName: 'events',             // optional
  snapshotsCollectionName: 'snapshots',       // optional
  transactionsCollectionName: 'transactions', // optional
  timeout: 10000                              // optional
  // authSource: 'authedicationDatabase',        // optional
  // username: 'technicalDbUser',                // optional
  // password: 'secret'                          // optional
});
```