### PR TITLE
Fix eventmappings when value is empty or 0

### DIFF
--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -402,7 +402,7 @@ _.extend(Eventstore.prototype, {
           event.streamRevision = currentRevision;
 
           _.each(_.keys(self.eventMappings), function (key) {
-            if (!util.isNullOrUndefined(event[key])) {
+            if (event[key] !== undefined && event[key] !== null) {
               dotty.put(event.payload, self.eventMappings[key], event[key]);
             }
           });

--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -402,7 +402,7 @@ _.extend(Eventstore.prototype, {
           event.streamRevision = currentRevision;
 
           _.each(_.keys(self.eventMappings), function (key) {
-            if (event[key]) {
+            if (!util.isNullOrUndefined(event[key])) {
               dotty.put(event.payload, self.eventMappings[key], event[key]);
             }
           });

--- a/test/eventstoreTest.js
+++ b/test/eventstoreTest.js
@@ -1420,6 +1420,33 @@ describe('eventstore', function () {
 
     });
 
+    describe('and defining the streamRevision option', function () {
+
+      it('it should save the streamRevision correctly', function (done) {
+
+        var es = eventstore();
+        es.defineEventMappings({ streamRevision: 'version' });
+        es.init(function (err) {
+          expect(err).not.to.be.ok();
+
+          es.getEventStream('streamIdWithDate', function (err, stream) {
+            stream.addEvent({ one: 'event' });
+
+            stream.commit(function (err, st) {
+              expect(err).not.to.be.ok();
+
+              expect(st.events.length).to.eql(1);
+              expect(st.events[0].payload.version).to.eql(st.events[0].streamRevision);
+
+              done();
+            });
+          });
+        });
+
+      });
+
+    });
+
     describe('and defining a publisher function in a synchronous way', function () {
 
       it('it should initialize an eventDispatcher', function (done) {


### PR DESCRIPTION
For streamRevision, for example, because 1st revision value is 0, streamRevision is not copied in the payload : the value is bypassed because of the test in the `if` statement