### PR TITLE
MongoDb: Add index used when querying for all events for an aggregate type

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -92,6 +92,8 @@ _.extend(Mongo.prototype, {
           function (err) { if (err) { debug(err); } });
         self.events.ensureIndex({ dispatched: 1 }, { sparse: true },
           function (err) { if (err) { debug(err); } });
+        self.events.ensureIndex({ commitStamp: 1, streamRevision: 1, commitSequence: 1 },
+          function (err) { if (err) { debug(err); } });
 
         self.snapshots = self.db.collection(options.snapshotsCollectionName);
         self.snapshots.ensureIndex({ aggregateId: 1, revision: -1 },


### PR DESCRIPTION
__Reason__
The index is needed when using this api call:

```js
store.getEvents({aggregate:'my-aggregate', skip, limit, cb)
```

_(the values of skip and limit don't matter)_

The query above is handled by this call to mongodb client:
```
this.events.find(findStatement, { sort: [
   ['commitStamp', 'asc'],
   ['streamRevision', 'asc'],
   ['commitSequence', 'asc']] }).toArray(function (err, res) {
```
https://github.com/adrai/node-eventstore/blob/v1.7.3/lib/databases/mongodb.js#L327

Without the index, MongoDb has to sort in memory, which works fine for few events, but with enough events you'll hit the ceiling and get an error, like this:

> Plan executor error during find: Overflow sort stage buffered data usage of 33554808 bytes exceeds internal limit of 33554432 bytes