### PR TITLE
keep events immutable: always deep clone events from in memory store

### DIFF
--- a/lib/databases/inmemory.js
+++ b/lib/databases/inmemory.js
@@ -136,14 +136,14 @@ _.extend(InMemory.prototype, {
     }
 
     if (limit === -1) {
-      return callback(null, res.slice(skip));
+      return callback(null, _.cloneDeep(res.slice(skip)));
     }
 
     if (res.length <= skip) {
       return callback(null, []);
     }
 
-    callback(null, res.slice(skip, skip + limit));
+    callback(null, _.cloneDeep(res.slice(skip, skip + limit)));
   },
 
   getEventsSince: function (date, skip, limit, callback) {
@@ -165,14 +165,14 @@ _.extend(InMemory.prototype, {
     });
 
     if (limit === -1) {
-      return callback(null, res.slice(skip));
+      return callback(null, _.cloneDeep(res.slice(skip)));
     }
 
     if (res.length <= skip) {
       return callback(null, []);
     }
 
-    callback(null, res.slice(skip, skip + limit));
+    callback(null, _.cloneDeep(res.slice(skip, skip + limit)));
   },
 
   getEventsByRevision: function (query, revMin, revMax, callback) {
@@ -190,7 +190,7 @@ _.extend(InMemory.prototype, {
       this.store[query.context][query.aggregate] = this.store[query.context][query.aggregate] || {};
 
       if (!this.store[query.context][query.aggregate][query.aggregateId]) {
-        return callback(null, res);
+        return callback(null, _.cloneDeep(res));
       }
       else {
         if (revMax === -1) {
@@ -200,7 +200,7 @@ _.extend(InMemory.prototype, {
           res = res.concat(this.store[query.context][query.aggregate][query.aggregateId].slice(revMin, revMax));
         }
       }
-      return callback(null, res);
+      return callback(null, _.cloneDeep(res));
     }
 
     if (!query.context && query.aggregate) {
@@ -215,7 +215,7 @@ _.extend(InMemory.prototype, {
           }
         }
       }
-      return callback(null, res);
+      return callback(null, _.cloneDeep(res));
     }
 
     if (query.context && !query.aggregate) {
@@ -231,7 +231,7 @@ _.extend(InMemory.prototype, {
           }
         }
       }
-      return callback(null, res);
+      return callback(null, _.cloneDeep(res));
     }
 
     if (!query.context && !query.aggregate) {
@@ -249,7 +249,7 @@ _.extend(InMemory.prototype, {
           }
         }
       }
-      return callback(null, res);
+      return callback(null, _.cloneDeep(res));
     }
   },
 


### PR DESCRIPTION
Fix for #66 

Only `in-memory` is affected so risk of regression should be minimal.