### PR TITLE
Support mongo connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ example with mongodb:
       // authSource: 'authedicationDatabase',        // optional
       // username: 'technicalDbUser',                // optional
       // password: 'secret'                          // optional
+      // url: 'mongodb://user:pass@host:port/db?opts // optional
     });
 
 example with redis:

--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -48,42 +48,49 @@ _.extend(Mongo.prototype, {
 
     var options = this.options;
 
-    var server;
+    var connectionUrl;
 
-    if (options.servers && Array.isArray(options.servers)){
-      var servers = [];
-
-      options.servers.forEach(function(item){
-        if(item.host && item.port) {
-          servers.push(new mongo.Server(item.host, item.port, item.options));
-        }
-      });
-
-      server = new mongo.ReplSet(servers);
+    if (options.url) {
+      connectionUrl = options.url;
     } else {
-      server = new mongo.Server(options.host, options.port, options.options);
+      var members = options.servers
+        ? options.servers
+        : [{host: options.host, port: options.port}];
+
+      var memberString = _(members).map(function(m) { return m.host + ':' + m.port });
+      var authString = options.username && options.password 
+        ? options.username + ':' + options.password
+        : '';
+      var optionsString = options.authSource
+        ? '?authSource=' + options.authSource
+        : '';
+
+      connectionUrl = 'mongodb://' + authString + memberString + '/' + options.database + optionsString;  
     }
 
-    this.db = new mongo.Db(options.dbName, server, { safe: true });
-    this.db.on('close', function() {
-      self.emit('disconnect');
-      self.stopHeartbeat();
-    });
+    var client = new mongo.MongoClient();
 
-    this.db.open(function (err, client) {
+    client.connect(connectionUrl, options.options, function(err, db) {
       if (err) {
         debug(err);
         if (callback) callback(err);
         return;
       }
+
+      self.db = db;
+
+      self.db.on('close', function() {
+        self.emit('disconnect');
+        self.stopHeartbeat();
+      });
+
+
       function finish (err) {
         if (err) {
           debug(err);
           if (callback) callback(err);
           return;
         }
-
-        self.client = client;
 
         self.events = self.db.collection(options.eventsCollectionName);
         self.events.ensureIndex({ aggregateId: 1, streamRevision: 1 },
@@ -108,16 +115,6 @@ _.extend(Mongo.prototype, {
           self.startHeartbeat();
         }
         if (callback) callback(null, self);
-      }
-
-      // Authenticate with authSource
-      if (options.authSource && options.username) {
-        // Authenticate with authSource
-        return client.authenticate(options.username, options.password, {authSource: options.authSource}, finish);
-      }
-
-      if (options.username) {
-        return client.authenticate(options.username, options.password, finish);
       }
 
       finish();

--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -59,13 +59,13 @@ _.extend(Mongo.prototype, {
 
       var memberString = _(members).map(function(m) { return m.host + ':' + m.port });
       var authString = options.username && options.password 
-        ? options.username + ':' + options.password
+        ? options.username + ':' + options.password + '@'
         : '';
       var optionsString = options.authSource
         ? '?authSource=' + options.authSource
         : '';
 
-      connectionUrl = 'mongodb://' + authString + memberString + '/' + options.database + optionsString;  
+      connectionUrl = 'mongodb://' + authString + memberString + '/' + options.dbName + optionsString;  
     }
 
     var client = new mongo.MongoClient();


### PR DESCRIPTION
Quick PR for #68. 

Use can now pass in a [mongo connection string](https://docs.mongodb.com/manual/reference/connection-string/) which is a lot more powerful than passing in individual host/port or servers.

As discussed in the issue, this is especially useful for supporting different environments (dev/prod etc).

Implemented by converting host/port/db/auth/servers etc to a connection string and using MongoClient.connect, which is more simple than the deprecated way of creating ReplSet/Servet etc depending on the parameters.

All tests pass except some unrelated elasticsearch/redis tests which I do not have installed.