### PR TITLE
Early abort when events were fetched without limit

### DIFF
--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -156,7 +156,9 @@ _.extend(Eventstore.prototype, {
         return callback(err);
       }
       evts.next = function (callback) {
-        skip += limit;
+        if (limit < 0) {
+          return process.nextTick(function () { callback(null, []) });
+        }
         self.getEvents(query, skip, limit, callback);
       };
 


### PR DESCRIPTION
When using MongoDB as backend and calling `es.getEvents((err, events) => { ... })`, any call to `events.next` will result in an error, as the current logic adds the default `-1` limit to the `skip` value of `0`, resulting in an invalid negative skip value. Invoking the callback in this case with an empty array should be a graceful fix.