### PR TITLE
Fix deprecated Redis defaults

### DIFF
--- a/lib/databases/redis.js
+++ b/lib/databases/redis.js
@@ -19,11 +19,9 @@ function Redis(options) {
     prefix: 'eventstore',
     eventsCollectionName: 'events',
     snapshotsCollectionName: 'snapshots',
-    max_attempts: 1,
     retry_strategy: function (options) {
       return undefined;
-    }//,
-    // heartbeat: 60 * 1000
+    }
   };
 
   _.defaults(options, defaults);


### PR DESCRIPTION
With the current defaults I get the following warning from Redis on connect:

```
node_redis: WARNING: You activated the retry_strategy and max_attempts at the same time. This is not possible and max_attempts will be ignored.
```