### PR TITLE
Prevent uncommittedEvents to be overwritten accidentally

### DIFF
--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -418,21 +418,23 @@ _.extend(Eventstore.prototype, {
           });
         }
 
-        self.store.addEvents(eventstream.uncommittedEvents, function(err) {
+        let uncommittedEvents = [].concat(eventstream.uncommittedEvents);
+        eventstream.uncommittedEvents = [];
+        self.store.addEvents(uncommittedEvents, function(err) {
           if (err) {
+            eventstream.uncommittedEvents = uncommittedEvents.concat(eventstream.uncommittedEvents);
             return callback(err);
           }
 
           if (self.publisher && self.dispatcher) {
             // push to undispatchedQueue
-            self.dispatcher.addUndispatchedEvents(eventstream.uncommittedEvents);
+            self.dispatcher.addUndispatchedEvents(uncommittedEvents);
           } else {
-            eventstream.eventsToDispatch = [].concat(eventstream.uncommittedEvents);
+            eventstream.eventsToDispatch = [].concat(uncommittedEvents);
           }
 
           // move to events and remove uncommitted events.
-          eventstream.events = eventstream.events.concat(eventstream.uncommittedEvents);
-          eventstream.uncommittedEvents = [];
+          eventstream.events = eventstream.events.concat(uncommittedEvents);
           eventstream.currentRevision();
 
           callback(null, eventstream);

--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -401,8 +401,10 @@ _.extend(Eventstore.prototype, {
         var event,
           currentRevision = eventstream.currentRevision();
 
-        for (var i = 0, len = eventstream.uncommittedEvents.length; i < len; i++) {
-          event = eventstream.uncommittedEvents[i];
+        let uncommittedEvents = [].concat(eventstream.uncommittedEvents);
+        eventstream.uncommittedEvents = [];
+        for (var i = 0, len = uncommittedEvents.length; i < len; i++) {
+          event = uncommittedEvents[i];
           event.id = id + i.toString();
           event.commitId = id;
           event.commitSequence = i;
@@ -418,10 +420,9 @@ _.extend(Eventstore.prototype, {
           });
         }
 
-        let uncommittedEvents = [].concat(eventstream.uncommittedEvents);
-        eventstream.uncommittedEvents = [];
         self.store.addEvents(uncommittedEvents, function(err) {
           if (err) {
+            // add uncommitted events back to eventstream
             eventstream.uncommittedEvents = uncommittedEvents.concat(eventstream.uncommittedEvents);
             return callback(err);
           }
@@ -433,7 +434,7 @@ _.extend(Eventstore.prototype, {
             eventstream.eventsToDispatch = [].concat(uncommittedEvents);
           }
 
-          // move to events and remove uncommitted events.
+          // move uncommitted events to events
           eventstream.events = eventstream.events.concat(uncommittedEvents);
           eventstream.currentRevision();
 

--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -399,9 +399,8 @@ _.extend(Eventstore.prototype, {
       function commitEvents(id, callback) {
         // start committing.
         var event,
-          currentRevision = eventstream.currentRevision();
-
-        let uncommittedEvents = [].concat(eventstream.uncommittedEvents);
+          currentRevision = eventstream.currentRevision(),
+          uncommittedEvents = [].concat(eventstream.uncommittedEvents);
         eventstream.uncommittedEvents = [];
         for (var i = 0, len = uncommittedEvents.length; i < len; i++) {
           event = uncommittedEvents[i];


### PR DESCRIPTION
This change avoids the eventstream to lose events from the uncommittedEvents list that were added in between the èventstore.commit` and `store.addEvents` call by only working on a copy of those.

Fixes #84