### PR TITLE
Optional dispatch table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ example with dynamodb:
         SnapshotReadCapacityUnits: 1,               // optional
         SnapshotWriteCapacityUnits: 3,              // optional
         UndispatchedEventsReadCapacityUnits: 1,     // optional
+        UndispatchedEventsReadCapacityUnits: 1,     // optional
+        useUndispatchedEventsTable: true            // optional
     });
 
 DynamoDB credentials are obtained by eventstore either from environment vars or credentials file. For setup see [AWS Javascript SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html).
@@ -129,6 +131,8 @@ DynamoDB provider supports [DynamoDB local](http://docs.aws.amazon.com/amazondyn
 Or on Windows:
 
     > set AWS_DYNAMODB_ENDPOINT=http://localhost:8000
+
+The **useUndispatchedEventsTable** option to available for those who prefer to use DyanmoDB.Streams to pull events from the store instead of the UndispatchedEvents table. The default is true. Setting this option to false will result in the UndispatchedEvents table not being created at all, the getUndispatchedEvents method will always return an empty array, and the setEventToDispatched will effectively do nothing. 
 
 ## Built-in event publisher (optional)
 

--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -825,7 +825,7 @@ var createTableIfNotExists = function (client, params, callback) {
           error("Error while creating " + r.definition.TableName + ": " + JSON.stringify(err, null, 2));
           cbCreate(err);
         } else {
-          debug(data.TableDefinition.TableName + "created. Waiting for activiation.");
+          debug(data.TableDescription.TableName + "created. Waiting for activiation.");
           cbCreate(null, { Table: { TableName: data.TableDescription.TableName, TableStatus: data.TableDescription.TableStatus } });
         }
       });

--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -46,7 +46,8 @@ function DynamoDB(options) {
     EventsReadCapacityUnits: 1,
     EventsWriteCapacityUnits: 3,
     SnapshotReadCapacityUnits: 1,
-    SnapshotWriteCapacityUnits: 1
+    SnapshotWriteCapacityUnits: 1,
+    useUndispatchedEventsTable: true
   };
 
   this.options = _.defaults(this.options, defaults);
@@ -71,7 +72,11 @@ _.extend(DynamoDB.prototype, {
     };
 
     var createUndispatchedEventsTable = function (done) {
-      createTableIfNotExists(self.client, UndispatchedEventsTableDefinition(self.options), done)
+      if (self.options.useUndispatchedEventsTable) {
+        createTableIfNotExists(self.client, UndispatchedEventsTableDefinition(self.options), done)
+      } else {
+        done();
+      }
     };
 
     async.parallel([
@@ -178,8 +183,10 @@ _.extend(DynamoDB.prototype, {
                 callback(null, data);
               }
             });
-          },
-          function (callback) {
+          }];
+
+        if (self.options.useUndispatchedEventsTable) {
+          results.push(function (callback) {
             var storedEvent = {
               TableName: self.options.undispatchedEventsTableName,
               Item: new StoredEvent(event),
@@ -194,8 +201,8 @@ _.extend(DynamoDB.prototype, {
                 callback(null, data);
               }
             });
-          }
-        ]
+          });
+        }
 
         callback(null, results);
       },
@@ -427,12 +434,14 @@ _.extend(DynamoDB.prototype, {
   },
 
   getUndispatchedEvents: function (query, callback) {
-
     var self = this;
     var client = new aws.DynamoDB.DocumentClient(self.options.endpointConf);
     var exclusiveStartKey = null;
     var entities = [];
 
+    if (!self.options.useUndispatchedEventsTable) return entities;
+
+    // TODO: use DynamoDB Streams instead
     var tableQuery = {
       TableName: self.options.undispatchedEventsTableName
     };
@@ -551,6 +560,8 @@ _.extend(DynamoDB.prototype, {
   setEventToDispatched: function (id, callback) {
     var self = this;
     var client = new aws.DynamoDB.DocumentClient(self.options.endpointConf);
+
+    if (!self.options.useUndispatchedEventsTable) return callback();
 
     var objDescriptor = {
       TableName: self.options.undispatchedEventsTableName,
@@ -915,13 +926,16 @@ var clearEventTables = function (opts, documentClient, cleared) {
         return { DeleteRequest: { Key: { aggregateId: n.aggregateId, rowKey: n.rowKey } } };
       }
     },
-    {
+  ];
+
+  if (opts.useUndispatchedEventsTable) {
+    maps.push({
       TableName: opts.undispatchedEventsTableName,
       keyMap: function (n) {
         return { DeleteRequest: { Key: { id: n.id } } };
       }
-    }
-  ];
+    });
+  }
 
   var read = function (task, callback) {
     documentClient.scan(task.params, function (err, page) {
@@ -982,6 +996,19 @@ var clearEventTables = function (opts, documentClient, cleared) {
   var tasks = [
     {
       params: {
+        TableName: opts.eventsTableName,
+        ProjectionExpression: "aggregateId,rowKey,id",
+        Limit: 25, // max 25 per batchWrite call 
+        ConsistentRead: false,
+        ReturnConsumedCapacity: "TOTAL"
+      },
+      maps: [maps[0]]
+    }
+  ];
+
+  if (opts.useUndispatchedEventsTable) {
+    tasks.splice(0, 0, {
+      params: {
         TableName: opts.undispatchedEventsTableName,
         ProjectionExpression: "aggregateId,rowKey,id",
         Limit: 12, // max 25 per batchWrite call divided by 2 tables
@@ -989,23 +1016,13 @@ var clearEventTables = function (opts, documentClient, cleared) {
         ReturnConsumedCapacity: "TOTAL"
       },
       maps: maps
-    },
-    {
-      params: {
-        TableName: opts.eventsTableName,
-        ProjectionExpression: "aggregateId,rowKey,id",
-        Limit: 25, // max 25 per batchWrite call 
-        ConsistentRead: false,
-        ReturnConsumedCapacity: "TOTAL"
-      },
-      maps: [ maps[0] ]
-    }
-  ];
+    });
+  }
 
   async.eachSeries(tasks, function (t, afterEach) {
-    
+
     async.doWhilst(function (next) {
-      
+
       if (exclusiveStartKey)
         t.params.ExclusiveStartKey = exclusiveStartKey;
 
@@ -1013,7 +1030,7 @@ var clearEventTables = function (opts, documentClient, cleared) {
         if (err) next(err);
         else next(null, result);
       });
-      
+
     }, function () {
       return exclusiveStartKey !== null;
     }, function (err, r) {
@@ -1022,7 +1039,7 @@ var clearEventTables = function (opts, documentClient, cleared) {
       }
       return afterEach();
     });
-    
+
   }, function (err) {
     if (err) {
       return cleared(err);

--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -5,7 +5,10 @@ var util = require('util'),
   _ = require('lodash'),
   async = require('async'),
   aws = Store.use('aws-sdk'),
-  debug = require('debug')('eventstore:store:dynamodb');
+  dbg = require('debug');
+
+var debug = dbg('eventstore:store:dynamodb'),
+  error = dbg("eventstore:store:dynamodb:error");
 
 /*
 for information on optimizing access patterns see: https://medium.com/building-timehop/one-year-of-dynamodb-at-timehop-f761d9fe5fa1
@@ -51,6 +54,7 @@ function DynamoDB(options) {
   };
 
   this.options = _.defaults(this.options, defaults);
+  debug(JSON.stringify(this.options, null, 2));
 }
 
 util.inherits(DynamoDB, Store);
@@ -85,7 +89,7 @@ _.extend(DynamoDB.prototype, {
       createUndispatchedEventsTable
     ], function (err) {
       if (err) {
-        debug(err);
+        error("connect error: " + err);
         if (callback) callback(err);
       } else {
         self.emit('connect');
@@ -105,7 +109,7 @@ _.extend(DynamoDB.prototype, {
     debug("remove all tables created for testing");
     deleteAllTempTables(self.client, self.options, function (err, result) {
       if (err) {
-        debug(err);
+        error("removeTables error: " + err);
         return done(err);
       }
       return done(null, result);
@@ -118,7 +122,7 @@ _.extend(DynamoDB.prototype, {
     var clearEvents = function (callback) {
       clearEventTables(self.options, self.documentClient, function (err) {
         if (err) {
-          debug(err);
+          error("clearEventTables error: " + err);
           return callback(err);
         }
 
@@ -129,7 +133,7 @@ _.extend(DynamoDB.prototype, {
     var clearSnapshots = function (callback) {
       clearSnapshotsTable(self.options, self.documentClient, function (err) {
         if (err) {
-          debug(err);
+          error("clearSnapshotsTable error: " + err);
           return callback(err);
         }
 
@@ -142,7 +146,7 @@ _.extend(DynamoDB.prototype, {
       clearSnapshots
     ], function (err, data) {
       if (err) {
-        debug(err);
+        error("removeTables error: " + err);
         if (done) done(err);
         return;
       }
@@ -159,7 +163,7 @@ _.extend(DynamoDB.prototype, {
 
     if (noAggId) {
       var errMsg = 'aggregateId not defined!';
-      debug(errMsg);
+      error(errMsg);
       if (callback) callback(new Error(errMsg));
       return;
     }
@@ -175,17 +179,20 @@ _.extend(DynamoDB.prototype, {
               ConditionExpression: "attribute_not_exists(aggregateId) and attribute_not_exists(rowKey)"
             };
 
+            debug("Saving event to events table: " + JSON.stringify(storedEvent, null, 2));
             self.documentClient.put(storedEvent, function (err, data) {
               if (err) {
-                debug(err);
+                error("dynamodb.addUndispatchedEvents error: " + JSON.stringify(err));
                 return callback(err);
               } else {
+                debug("event saved");
                 callback(null, data);
               }
             });
           }];
 
         if (self.options.useUndispatchedEventsTable) {
+          debug("using undispatchedevents table");
           results.push(function (callback) {
             var storedEvent = {
               TableName: self.options.undispatchedEventsTableName,
@@ -193,11 +200,13 @@ _.extend(DynamoDB.prototype, {
               ConditionExpression: "attribute_not_exists(id)"
             };
 
+            debug("Saving event to undispatchedevents table " + JSON.stringify(storedEvent, null, 2));
             self.documentClient.put(storedEvent, function (err, data) {
               if (err) {
-                debug(err);
+                error("dynamodb.addUndispatchedEvents error: " + JSON.stringify(err));
                 return callback(err);
               } else {
+                debug("undispatched event saved");
                 callback(null, data);
               }
             });
@@ -208,7 +217,7 @@ _.extend(DynamoDB.prototype, {
       },
       function (err, results) {
         if (err) {
-          debug(err);
+          error("addEvents error: " + JSON.stringify(err));
         }
         async.parallel(results, callback);
       }
@@ -263,7 +272,7 @@ _.extend(DynamoDB.prototype, {
       if (tableQuery.KeyConditionExpression) {
         client.query(tableQuery, function (err, results) {
           if (err) {
-            debug(err);
+            error("getEvents query error: " + err);
             return end(err);
           }
           exclusiveStartKey = results.LastEvaluatedKey || null;
@@ -274,7 +283,7 @@ _.extend(DynamoDB.prototype, {
         // no great 2ndary index possibilities here - avoid calling getItems w/o aggregateId
         client.scan(tableQuery, function (err, results) {
           if (err) {
-            debug(err);
+            error("getEvents scan error: " + err);
             return end(err);
           }
 
@@ -287,7 +296,7 @@ _.extend(DynamoDB.prototype, {
       return (entities.length < pageSize || pageSize == -1) ? exclusiveStartKey !== null : false;
     }, function (err) {
       if (err) {
-        debug(err);
+        error("getEvents error: " + err);
         return callback(err);
       }
 
@@ -330,7 +339,7 @@ _.extend(DynamoDB.prototype, {
       // scan is just really inefficient but if you need to do it often a query on a 2ndary IDX *might* help
       client.scan(tableQuery, function (err, results) {
         if (err) {
-          debug(err);
+          error("getEventsSince scan error: " + err);
           return end(err);
         }
 
@@ -342,8 +351,7 @@ _.extend(DynamoDB.prototype, {
       return (entities.length < pageSize || pageSize == -1) ? exclusiveStartKey !== null : false;
     }, function (err) {
       if (err) {
-        debug("getEventsSince: " + date.getTime());
-        debug(err);
+        error("getEventsSince error: " + err);
         return callback(err);
       }
 
@@ -372,7 +380,7 @@ _.extend(DynamoDB.prototype, {
 
     if (!query.aggregateId) {
       var errMsg = 'aggregateId not defined!';
-      debug(errMsg);
+      error(errMsg);
       if (callback) callback(new Error(errMsg));
       return;
     }
@@ -408,7 +416,7 @@ _.extend(DynamoDB.prototype, {
 
       client.query(tableQuery, function (err, results) {
         if (err) {
-          debug(err);
+          error("getEventsByRevision query error: " + err);
           return end(err);
         }
         exclusiveStartKey = results.LastEvaluatedKey || null;
@@ -419,7 +427,7 @@ _.extend(DynamoDB.prototype, {
       return exclusiveStartKey !== null;
     }, function (err) {
       if (err) {
-        debug(err);
+        error("getEventsByRevision error: " + err);
         return callback(err);
       }
 
@@ -477,7 +485,7 @@ _.extend(DynamoDB.prototype, {
 
       client.scan(tableQuery, function (err, results) {
         if (err) {
-          debug(err);
+          error("getUndispatchedEvents scan error: " + err);
           return end(err);
         }
 
@@ -489,7 +497,7 @@ _.extend(DynamoDB.prototype, {
       return exclusiveStartKey !== null;
     }, function (err) {
       if (err) {
-        debug(err);
+        error("getUndispatchedEvents error: " + err);
         return callback(err);
       }
 
@@ -512,7 +520,7 @@ _.extend(DynamoDB.prototype, {
 
     if (!query.aggregateId) {
       var errMsg = 'aggregateId not defined!';
-      debug(errMsg);
+      error(errMsg);
       if (callback) callback(new Error(errMsg));
       return;
     }
@@ -530,7 +538,7 @@ _.extend(DynamoDB.prototype, {
 
       client.query(tableQuery, function (err, results) {
         if (err) {
-          debug(err);
+          error("getLastEvent query error: " + err);
           return end(err);
         }
         exclusiveStartKey = results.LastEvaluatedKey || null;
@@ -541,7 +549,7 @@ _.extend(DynamoDB.prototype, {
       return exclusiveStartKey !== null;
     }, function (err) {
       if (err) {
-        debug(err);
+        error("getLastEvent error: " + err);
         return callback(err);
       }
 
@@ -579,7 +587,7 @@ _.extend(DynamoDB.prototype, {
 
     if (!snap.aggregateId) {
       var errMsg = 'aggregateId not defined!';
-      debug(errMsg);
+      error(errMsg);
       if (callback) callback(new Error(errMsg));
       return;
     }
@@ -591,9 +599,7 @@ _.extend(DynamoDB.prototype, {
     }
     client.put(snapshot, function (err, data) {
       if (err) {
-        debug("addSnapshot error: ");
-        debug(snapshot);
-        debug(err);
+        error("addSnapshot error: " + err);
         return callback(err);
       }
       callback(null, data);
@@ -648,7 +654,7 @@ _.extend(DynamoDB.prototype, {
 
       client.query(tableQuery, function (err, results) {
         if (err) {
-          debug(err);
+          debug("getSnapshot query error: " + err);
           return end(err);
         }
         exclusiveStartKey = results.LastEvaluatedKey || null;
@@ -659,7 +665,7 @@ _.extend(DynamoDB.prototype, {
       return exclusiveStartKey !== null;
     }, function (err) {
       if (err) {
-        debug(err);
+        error("getSnapshot error: " + err);
         return callback(err);
       }
 
@@ -675,6 +681,7 @@ _.extend(DynamoDB.prototype, {
 });
 
 var StoredEvent = function (event) {
+  debug("Converting event to StoredEvent: " + JSON.stringify(event, null, 2));
   this.aggregateId = event.aggregateId;
   this.rowKey = new Date(event.commitStamp).toISOString() + ":" + (event.context || "") + ":" + (event.aggregate || "") + ":" + event.streamRevision;
   this.id = event.id;
@@ -687,6 +694,7 @@ var StoredEvent = function (event) {
   this.header = event.header;
   this.dispatched = event.dispatched || false;
   this.payload = JSON.stringify(event.payload);
+  debug("Event converted to StoredEvent: " + JSON.stringify(this, null, 2));
 };
 
 function MapStoredEventToEvent(storedEvent) {
@@ -796,11 +804,14 @@ var createTableIfNotExists = function (client, params, callback) {
     client.describeTable({ TableName: p.TableName }, function (err, data) {
       if (err) {
         if (err.code === "ResourceNotFoundException") {
+          debug("Table " + p.TableName + " already exists: " + JSON.stringify(p, null, 2));
           cbExists(null, { exists: false, definition: p });
         } else {
+          error("Table " + p.TableName + " doesn't exist yet but describeTable: " + JSON.stringify(err, null, 2));
           cbExists(err);
         }
       } else {
+        debug("Table " + p.TableName + " already exists.");
         cbExists(null, { exists: true, description: data });
       }
     });
@@ -808,10 +819,13 @@ var createTableIfNotExists = function (client, params, callback) {
 
   var create = function (r, cbCreate) {
     if (!r.exists) {
+      debug("Creating " + r.definition.TableName);
       client.createTable(r.definition, function (err, data) {
         if (err) {
+          error("Error while creating " + r.definition.TableName + ": " + JSON.stringify(err, null, 2));
           cbCreate(err);
         } else {
+          debug(data.TableDefinition.TableName + "created. Waiting for activiation.");
           cbCreate(null, { Table: { TableName: data.TableDescription.TableName, TableStatus: data.TableDescription.TableStatus } });
         }
       });
@@ -825,8 +839,10 @@ var createTableIfNotExists = function (client, params, callback) {
     async.until(
       function () { return status === "ACTIVE" },
       function (cbUntil) {
+        debug("checking " + d.Table.TableName + " status.");
         client.describeTable({ TableName: d.Table.TableName }, function (err, data) {
           if (err) {
+            error("There was an error checking " + d.Table.TableName + " status: " + JSON.stringify(err, null, 2));
             cbUntil(err);
           } else {
             status = data.Table.TableStatus;
@@ -836,10 +852,10 @@ var createTableIfNotExists = function (client, params, callback) {
       },
       function (err, r) {
         if (err) {
-          debug("connect create table error:");
-          debug(err);
+          error("connect create table error: " + err);
           return cbActive(err);
         }
+        debug("Table " + d.Table.TableName + " is active.");
         cbActive(null, r);
       });
   };
@@ -857,7 +873,7 @@ var deleteTableIfExists = function (client, tableName, callback) {
         if (err.code === "ResourceNotFoundException") {
           cbExists(null, { exists: false, definition: { TableName: name } });
         } else {
-          debug("deleteTableIfExists - describeTable error: " + JSON.stringify(err, null, 2));
+          error("deleteTableIfExists - describeTable error: " + JSON.stringify(err, null, 2));
           cbExists(err);
         }
       } else {
@@ -870,7 +886,7 @@ var deleteTableIfExists = function (client, tableName, callback) {
     if (r.exists) {
       client.deleteTable(r.description, function (err, data) {
         if (err) {
-          debug("Error deleting '" + r.description.TableName + "': " + JSON.stringify(err, null, 2));
+          error("Error deleting '" + r.description.TableName + "': " + JSON.stringify(err, null, 2));
           cbDelete(err);
         } else {
           cbDelete(null, { Table: { TableName: data.TableDescription.TableName, TableStatus: data.TableDescription.TableStatus } });
@@ -892,7 +908,7 @@ var deleteTableIfExists = function (client, tableName, callback) {
               status = "DELETED";
               return cbUntil(null, d.Table.TableName);
             }
-            debug("Error calling describeTable for '" + d.Table.TableName + "'");
+            error("Error calling describeTable for '" + d.Table.TableName + "'");
             cbUntil(err);
           } else {
             setTimeout(cbUntil(null, data), 1000);
@@ -901,8 +917,7 @@ var deleteTableIfExists = function (client, tableName, callback) {
       },
       function (err, r) {
         if (err) {
-          debug("connect delete table error:");
-          debug(err);
+          error("connect delete table error: " + err);
           return cbActive(err);
         }
         cbActive(null, r);
@@ -919,6 +934,7 @@ var clearEventTables = function (opts, documentClient, cleared) {
   var exclusiveStartKey = null;
   var retryCount = 0;
 
+  debug("clearning events tables");
   var maps = [
     {
       TableName: opts.eventsTableName,
@@ -940,6 +956,7 @@ var clearEventTables = function (opts, documentClient, cleared) {
   var read = function (task, callback) {
     documentClient.scan(task.params, function (err, page) {
       if (err) {
+        error("clearEventTables scan error: " + err);
         return callback(err);
       }
 
@@ -967,9 +984,10 @@ var clearEventTables = function (opts, documentClient, cleared) {
 
   var write = function (batch, callback) {
     if (batch && batch.RequestItems) {
+      debug("Clear: calling batchWrite: " + JSON.stringify(batch, null, 2));
       documentClient.batchWrite(batch, function (err, result) {
         if (err) {
-          debug(JSON.stringify(batch, null, 2));
+          error("Clear (batchWrite) error): " + JSON.stringify(batch, null, 2));
           return callback(err);
         }
 
@@ -980,6 +998,7 @@ var clearEventTables = function (opts, documentClient, cleared) {
             ReturnConsumedCapacity: "INDEXES",
             ReturnItemCollectionMetrics: "SIZE"
           };
+          debug("Clear batchWrite throttling: " + JSON.stringify(retry, null, 2));
           // retry with exponential backoff
           var delay = retryCount > 0 ? (50 * Math.pow(2, retryCount - 1)) : 0;
           setTimeout(write(retry, callback), delay);
@@ -1035,6 +1054,7 @@ var clearEventTables = function (opts, documentClient, cleared) {
       return exclusiveStartKey !== null;
     }, function (err, r) {
       if (err) {
+        error("clearEvents error: " + err);
         return afterEach(err);
       }
       return afterEach();
@@ -1042,8 +1062,10 @@ var clearEventTables = function (opts, documentClient, cleared) {
 
   }, function (err) {
     if (err) {
+      error("Error while clearning events tables: " + JSON.stringify(err, null, 2));
       return cleared(err);
     }
+    debug("Events tables successfully cleared.");
     return cleared();
   });
 
@@ -1066,7 +1088,7 @@ var clearSnapshotsTable = function (opts, documentClient, cleared) {
 
     documentClient.scan(query, function (err, page) {
       if (err) {
-        debug(err);
+        error("clearSnapshotsTable scan error: " + err);
         return end(err);
       }
 
@@ -1087,15 +1109,16 @@ var clearSnapshotsTable = function (opts, documentClient, cleared) {
       };
       batch.RequestItems[opts.snapshotsTableName] = keys;
 
-      documentClient.batchWrite(batch, function (error, data) {
-        return end(error);
+      documentClient.batchWrite(batch, function (err2, data) {
+        error("clearSnapshotsTable batchWrite error: " + err2);
+        return end(err2);
       });
     });
   }, function () {
     return exclusiveStartKey !== null;
   }, function (err, r) {
     if (err) {
-      debug(err);
+      error("clearSnapshotsTable error: " + err);
       return cleared(error);
     }
     return cleared(null);;
@@ -1111,7 +1134,7 @@ var deleteAllTempTables = function (client, opts, done) {
 
     client.listTables(query, function (err, list) {
       if (err) {
-        debug(err);
+        error("deleteAllTempTables listTables error: " + err);
         return callback(err);
       }
 
@@ -1131,7 +1154,7 @@ var deleteAllTempTables = function (client, opts, done) {
       deleteTableIfExists(client, t, deleted);
     }, function (err) {
       if (err) {
-        debug(err);
+        error("deleteAllTempTables drop error: " + err);
         return callback(err);
       }
       return callback(null);
@@ -1147,7 +1170,7 @@ var deleteAllTempTables = function (client, opts, done) {
     return exclusiveStartTableName !== null;
   }, function (err, result) {
     if (err) {
-      debug(err);
+      error("deleteAllTempTables error: " + err);
       return done(err);
     }
     done(null, result);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tolerance": "1.0.0"
   },
   "devDependencies": {
-    "aws-sdk": ">=2.4.11",
+    "aws-sdk": ">=2.4.9",
     "azure-storage": ">=0.10.0",
     "cradle": ">=0.7.1",
     "elasticsearch": ">=10.0.0",


### PR DESCRIPTION
Because DynamoDB has the DynamDB.Streams feature which allows streaming output of all changes to a table it is cheaper to use this feature than UndispatchedEvents. So I've added a flag to disable the use of the UndispatchedEvents tables for those who prefer to read from the stream instead.