### PR TITLE
ability to use custom elasticsearch client in the elasticsearch storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,31 @@ example with elasticsearch:
       log: 'warning',                             // optional
       maxSearchResults: 10000                     // optional
     });
+	
+example with custom elasticsearch client (e.g. with AWS ElasticSearch client. Note ``` http-aws-es ``` package usage in this example):
 
+    var elasticsearch = require('elasticsearch');
+
+    var esClient = = new elasticsearch.Client({
+      hosts: 'SOMETHING.es.amazonaws.com',
+      connectionClass: require('http-aws-es'),
+      amazonES: {
+        region: 'us-east-1',
+        accessKey: 'REPLACE_AWS_accessKey',
+        secretKey: 'REPLACE_AWS_secretKey'
+      }
+    });
+	
+    var es = require('eventstore')({
+      type: 'elasticsearch',
+      client: esClient,
+      indexName: 'eventstore',
+      eventsTypeName: 'events',
+      snapshotsTypeName: 'snapshots',
+      log: 'warning',
+      maxSearchResults: 10000
+	});
+	
 example with azuretable:
 
     var es = require('eventstore')({

--- a/lib/databases/elasticsearch.js
+++ b/lib/databases/elasticsearch.js
@@ -42,7 +42,11 @@ _.extend(Elastic.prototype, {
 
   connect: function (callback) {
     var options = this.options;
-    this.client = new elasticsearch.Client({host: options.host, log: options.log});
+    if (options.client) {
+		this.client = options.client;
+	} else {
+		this.client = new elasticsearch.Client({host: options.host, log: options.log});
+	}
     this.emit('connect');
     if (callback) callback(null);
   },


### PR DESCRIPTION
Sometimes it's required to manually create ES client, e.g. Amazon AWS ElasticSearch service client or some additional options should be set (e.g. timeouts). So I add an option to pass existed ES client object into the storage via options.
