### PR TITLE
improve event revision accuracy in redis, to avoid revisions duplications for an aggregate

### DIFF
--- a/lib/databases/redis.js
+++ b/lib/databases/redis.js
@@ -284,7 +284,7 @@ _.extend(Redis.prototype, {
       }
 
       var undispKeysEvtMap = events.map(function (event, index) {
-        event.streamRevision = replies[index]; // mutates events passed as parameter
+        event.streamRevision = parseInt(replies[index], 10); // mutates events passed as parameter
         var key = self.options.prefix + ':undispatched_' + self.options.eventsCollectionName + ':' + eventKey(event);
         return [key, JSON.stringify(event)];
       });

--- a/lib/databases/redis.js
+++ b/lib/databases/redis.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('util'),
+  fs = require('fs'),
   Store = require('../base'),
   _ = require('lodash'),
   async = require('async'),
@@ -119,16 +120,44 @@ _.extend(Redis.prototype, {
         self.client.send_anyways = false;
       }
 
-      self.emit('connect');
+      self.deployLuaScripts(function (error) {
+        if (error) {
+          debug(error);
+          callback(error, self);
+        }
 
-      if (self.options.heartbeat) {
-        self.startHeartbeat();
+        self.emit('connect');
+
+        if (self.options.heartbeat) {
+          self.startHeartbeat();
+        }
+
+        if (calledBack) return;
+        calledBack = true;
+        if (callback) callback(null, self);
+      });
+
+    });
+  },
+
+  deployLuaScripts: function (callback) {
+    var self = this;
+
+    fs.readFile(__dirname + '/redis/commit.lua', {encoding: 'utf8'}, function (error, script) {
+      if (error) {
+        debug(error);
+        return callback(error);
       }
 
-      if (calledBack) return;
-      calledBack = true;
-      if (callback) callback(null, self);
-    });
+      self.client.script('load', script, function (error, sha1) {
+        if (error) {
+          debug(error);
+          return callback(error);
+        }
+        self.commitScript = sha1;
+        callback();
+      });
+    })
   },
 
   stopHeartbeat: function () {
@@ -207,24 +236,14 @@ _.extend(Redis.prototype, {
   addEvents: function (events, callback) {
 
     var self = this;
-    var noAggId = false;
-
-    var keysEvtMap = [];
-    var undispKeysEvtMap = [];
 
     var aggregateId = events[0].aggregateId;
     var aggregate = events[0].aggregate || '_general';
     var context = events[0].context || '_general';
 
-    _.each(events, function (evt) {
-      if (!evt.aggregateId) {
-        noAggId = true;
-      }
-      keysEvtMap.push(self.options.prefix + ':' + self.options.eventsCollectionName + ':' + evt.commitStamp.getTime() + ':' + evt.commitSequence.toString() + ':' + context + ':' + aggregate + ':' + aggregateId + ':' + evt.id);
-      keysEvtMap.push(JSON.stringify(evt));
-      undispKeysEvtMap.push(self.options.prefix + ':undispatched_' + self.options.eventsCollectionName + ':' + evt.commitStamp.getTime() + ':' + evt.commitSequence.toString() + ':' + context + ':' + aggregate + ':' + aggregateId + ':' + evt.id);
-      undispKeysEvtMap.push(JSON.stringify(evt));
-    });
+    var noAggId = events.filter(function (event) {
+      return !event.aggregateId
+    }).length > 0;
 
     if (noAggId) {
       var errMsg = 'aggregateId not defined!';
@@ -237,9 +256,42 @@ _.extend(Redis.prototype, {
       return callback(null);
     }
 
-    var args = keysEvtMap.concat(undispKeysEvtMap).concat([callback]);
+    function eventKey(event) {
+      return event.commitStamp.getTime() + ':' + event.commitSequence.toString() + ':' + context + ':' + aggregate + ':' + aggregateId + ':' + event.id;
+    }
 
-    this.client.mset.apply(this.client, args);
+    var multi = events.reduce(function(multi, event) {
+      var prefix = self.options.prefix + ':' + self.options.eventsCollectionName;
+      var key = prefix + ':' + eventKey(event);
+      var revisionKey = prefix + ':' + context + ':' + aggregate + ':' + aggregateId;
+
+      return multi.evalsha(self.commitScript, 3, key, JSON.stringify(event), revisionKey);
+    }, this.client.multi());
+
+    multi.exec(function (error, replies) {
+      if (error) {
+        debug(error);
+        return callback(error);
+      }
+
+      var errors = replies.filter(function (reply) {
+        return reply instanceof Error
+      });
+
+      if (errors.length) {
+        var message = 'error while adding events for aggregate ' + aggregate + ' ' + aggregateId;
+        return callback(new Error(message + '\n' + errors.join('\n')));
+      }
+
+      var undispKeysEvtMap = events.map(function (event, index) {
+        event.streamRevision = replies[index]; // mutates events passed as parameter
+        var key = self.options.prefix + ':undispatched_' + self.options.eventsCollectionName + ':' + eventKey(event);
+        return [key, JSON.stringify(event)];
+      });
+
+      var args = _.flatten(undispKeysEvtMap).concat(callback);
+      self.client.mset.apply(self.client, args);
+    });
   },
 
   scan: function (key, cursor, handleKeys, callback) {

--- a/lib/databases/redis/commit.lua
+++ b/lib/databases/redis/commit.lua
@@ -1,0 +1,9 @@
+local key = KEYS[1]
+local event = cjson.decode(KEYS[2])
+local revisionKey = KEYS[3] .. ':revision'
+
+local revision = redis.call('INCR', revisionKey)
+event['streamRevision'] = revision
+redis.call('SET', key, cjson.encode(event))
+
+return revision

--- a/lib/databases/redis/commit.lua
+++ b/lib/databases/redis/commit.lua
@@ -2,7 +2,9 @@ local key = KEYS[1]
 local event = cjson.decode(KEYS[2])
 local revisionKey = KEYS[3] .. ':revision'
 
-local revision = redis.call('INCR', revisionKey)
+local revision = redis.call('GET', revisionKey)
+if (not revision) then revision = 0 end
+redis.call('INCR', revisionKey)
 event['streamRevision'] = revision
 redis.call('SET', key, cjson.encode(event))
 

--- a/test/eventstoreTest.js
+++ b/test/eventstoreTest.js
@@ -821,7 +821,11 @@ describe('eventstore', function () {
                   snapshotsTableName: 'snapshots' + token
               }
             }
-
+            if (type === 'redis') {
+              options = {
+                db: 3
+              };
+            }
             options.type = type;
           });
 
@@ -1282,7 +1286,7 @@ describe('eventstore', function () {
                       }, function (err) {
                         expect(err).not.to.be.ok();
 
-                        stream.addEvent({ fourSnap: 'event4' })
+                        stream.addEvent({ fourSnap: 'event4' });
 
                         stream.commit(function(err, str) {
                           expect(err).not.to.be.ok();

--- a/test/storeTest.js
+++ b/test/storeTest.js
@@ -4,7 +4,7 @@ var expect = require('expect.js'),
   _ = require('lodash'),
   crypto = require('crypto');
 
-var types = ['inmemory', 'tingodb', 'mongodb'/*, 'redis', 'azuretable', 'elasticsearch', 'dynamodb'*/];
+var types = ['inmemory', 'tingodb', 'mongodb', 'redis'/*, 'azuretable', 'elasticsearch', 'dynamodb'*/];
 
 var token = crypto.randomBytes(16).toString('hex');
 
@@ -34,6 +34,11 @@ types.forEach(function (type) {
               undispatchedEventsTableName: 'undispatchedevents' + token,
               snapshotsTableName: 'snapshots' + token
           }
+        }
+        if (type === 'redis') {
+          options = {
+            db: 3
+          };
         }
         store = new Store(options);
       });


### PR DESCRIPTION
instead of using last event revision, redis use a lua script so that revision is always accurate
Fixes #90