### PR TITLE
fix calculated streamRevision for redis to avoid events sorting issues

### DIFF
--- a/lib/databases/redis/commit.lua
+++ b/lib/databases/redis/commit.lua
@@ -5,7 +5,7 @@ local revisionKey = KEYS[3] .. ':revision'
 local revision = redis.call('GET', revisionKey)
 if (not revision) then revision = 0 end
 redis.call('INCR', revisionKey)
-event['streamRevision'] = revision
+event['streamRevision'] = tonumber(revision)
 redis.call('SET', key, cjson.encode(event))
 
-return revision
+return tonumber(revision)

--- a/test/storeTest.js
+++ b/test/storeTest.js
@@ -226,6 +226,7 @@ types.forEach(function (type) {
                     expect(evts[1].aggregateId).to.eql(event2.aggregateId);
                     expect(evts[1].commitId).to.eql(event2.commitId);
                     expect(evts[1].payload.event).to.eql(event2.payload.event);
+                    expect(evts[1].streamRevision).to.be.a('number');
 
                     store.getLastEvent({ aggregateId: event2.aggregateId }, function(err, evt) {
                       expect(err).not.to.be.ok();


### PR DESCRIPTION
streamRevision field of an event calculated in lua script was not casted to an int
it could cause a sorting issue of events when they are loaded