### PR TITLE
changed addEvents to use sequential async methods instead of parallel

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -167,7 +167,7 @@ _.extend(DynamoDB.prototype, {
       return;
     }
 
-    async.concat(events,
+    async.concatSeries(events,
       function (event, callback) {
 
         var results = [
@@ -221,7 +221,7 @@ _.extend(DynamoDB.prototype, {
         if (err) {
           error("addEvents error: " + JSON.stringify(err));
         }
-        async.parallel(results, callback);
+        async.series(results, callback);
       }
     );
   },


### PR DESCRIPTION
DynamoDB Streams outputs events in the order they were received, so if events are committed out of order the stream will publish the events in the wrong order. 

AddEvents has been changed to use sequential async methods instead of parallel to correct out of order events in the stream.