### PR TITLE
Fix empty array conversion due to Lua json decode

### DIFF
--- a/lib/databases/redis.js
+++ b/lib/databases/redis.js
@@ -120,44 +120,16 @@ _.extend(Redis.prototype, {
         self.client.send_anyways = false;
       }
 
-      self.deployLuaScripts(function (error) {
-        if (error) {
-          debug(error);
-          callback(error, self);
-        }
+      self.emit('connect');
 
-        self.emit('connect');
-
-        if (self.options.heartbeat) {
-          self.startHeartbeat();
-        }
-
-        if (calledBack) return;
-        calledBack = true;
-        if (callback) callback(null, self);
-      });
-
-    });
-  },
-
-  deployLuaScripts: function (callback) {
-    var self = this;
-
-    fs.readFile(__dirname + '/redis/commit.lua', {encoding: 'utf8'}, function (error, script) {
-      if (error) {
-        debug(error);
-        return callback(error);
+      if (self.options.heartbeat) {
+        self.startHeartbeat();
       }
 
-      self.client.script('load', script, function (error, sha1) {
-        if (error) {
-          debug(error);
-          return callback(error);
-        }
-        self.commitScript = sha1;
-        callback();
-      });
-    })
+      if (calledBack) return;
+      calledBack = true;
+      if (callback) callback(null, self);
+    });
   },
 
   stopHeartbeat: function () {
@@ -260,22 +232,20 @@ _.extend(Redis.prototype, {
       return event.commitStamp.getTime() + ':' + event.commitSequence.toString() + ':' + context + ':' + aggregate + ':' + aggregateId + ':' + event.id;
     }
 
-    var multi = events.reduce(function(multi, event) {
-      var prefix = self.options.prefix + ':' + self.options.eventsCollectionName;
-      var key = prefix + ':' + eventKey(event);
-      var revisionKey = prefix + ':' + context + ':' + aggregate + ':' + aggregateId;
-
-      return multi.evalsha(self.commitScript, 3, key, JSON.stringify(event), revisionKey);
+    var prefix = self.options.prefix + ':' + self.options.eventsCollectionName;
+    var revisionKey = prefix + ':' + context + ':' + aggregate + ':' + aggregateId + ':revision';
+    var multi = events.reduce(function (multi) {
+      return multi.incr(revisionKey);
     }, this.client.multi());
 
-    multi.exec(function (error, replies) {
+    multi.exec(function (error, revisions) {
       if (error) {
         debug(error);
         return callback(error);
       }
 
-      var errors = replies.filter(function (reply) {
-        return reply instanceof Error
+      var errors = revisions.filter(function (reply) {
+        return reply instanceof Error;
       });
 
       if (errors.length) {
@@ -283,13 +253,21 @@ _.extend(Redis.prototype, {
         return callback(new Error(message + '\n' + errors.join('\n')));
       }
 
-      var undispKeysEvtMap = events.map(function (event, index) {
-        event.streamRevision = parseInt(replies[index], 10); // mutates events passed as parameter
+      var savedKeysAndEvents = events.map(function(event, index) {
+        var key = prefix + ':' + eventKey(event);
+        event.streamRevision = parseInt(revisions[index], 10) - 1;
+        event.applyMappings();
+        return [key, JSON.stringify(event)];
+      });
+
+      var undispatchedKeysAndEvents = events.map(function (event) {
         var key = self.options.prefix + ':undispatched_' + self.options.eventsCollectionName + ':' + eventKey(event);
         return [key, JSON.stringify(event)];
       });
 
-      var args = _.flatten(undispKeysEvtMap).concat(callback);
+      var args = _.flatten(savedKeysAndEvents)
+        .concat(_.flatten(undispatchedKeysAndEvents))
+        .concat(callback);
       self.client.mset.apply(self.client, args);
     });
   },

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var debug = require('debug')('eventstore:event'),
+  dotty = require('dotty'),
   _ = require('lodash');
 
 /**
@@ -9,7 +10,7 @@ var debug = require('debug')('eventstore:event'),
  * @param {Object}      event       the event object
  * @constructor
  */
-function Event (eventstream, event) {
+function Event (eventstream, event, eventMappings) {
   if (!eventstream) {
     var errStreamMsg = 'eventstream not injected!';
     debug(errStreamMsg);
@@ -34,6 +35,8 @@ function Event (eventstream, event) {
     throw new Error(errAggIdMsg);
   }
 
+  eventMappings = eventMappings || {};
+
   this.streamId = eventstream.aggregateId;
   this.aggregateId = eventstream.aggregateId;
   this.aggregate = eventstream.aggregate;
@@ -43,6 +46,14 @@ function Event (eventstream, event) {
   this.commitSequence = null;
   this.commitStamp = null;
   this.payload = event || null;
+
+  this.applyMappings = function applyMappings() {
+    _.keys(eventMappings).forEach(function (key) {
+      if (this[key] !== undefined && this[key] !== null) {
+        dotty.put(this.payload, eventMappings[key], this[key]);
+      }
+    }.bind(this));
+  };
 
   eventstream.uncommittedEvents.push(this);
 }

--- a/lib/eventStream.js
+++ b/lib/eventStream.js
@@ -90,7 +90,7 @@ EventStream.prototype = {
    * @param {Object} event
    */
   addEvent: function(event) {
-    new Event(this, event);
+    new Event(this, event, this.eventstore.eventMappings);
   },
 
   /**

--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -4,7 +4,6 @@ var debug = require('debug')('eventstore'),
   util = require('util'),
   EventEmitter = require('events').EventEmitter,
   _ = require('lodash'),
-  dotty = require('dotty'),
   async = require('async'),
   tolerate = require('tolerance'),
   EventDispatcher = require('./eventDispatcher'),
@@ -412,11 +411,7 @@ _.extend(Eventstore.prototype, {
           currentRevision++;
           event.streamRevision = currentRevision;
 
-          _.each(_.keys(self.eventMappings), function (key) {
-            if (event[key] !== undefined && event[key] !== null) {
-              dotty.put(event.payload, self.eventMappings[key], event[key]);
-            }
-          });
+          event.applyMappings();
         }
 
         self.store.addEvents(uncommittedEvents, function(err) {

--- a/test/storeTest.js
+++ b/test/storeTest.js
@@ -158,7 +158,8 @@ types.forEach(function (type) {
                   commitSequence: 0,
                   payload: {
                     event:'bla'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 store.addEvents([event], function(err) {
@@ -172,6 +173,40 @@ types.forEach(function (type) {
                     expect(evts[0].aggregateId).to.eql(event.aggregateId);
                     expect(evts[0].commitId).to.eql(event.commitId);
                     expect(evts[0].payload.event).to.eql(event.payload.event);
+
+                    done();
+                  });
+                });
+
+              });
+
+            });
+
+            describe('with an array in the payload', function () {
+
+              it('it should save the event', function(done) {
+
+                var event = {
+                  aggregateId: 'id1',
+                  id: '111',
+                  streamRevision: 0,
+                  commitId: '111',
+                  commitStamp: new Date(),
+                  commitSequence: 0,
+                  payload: {
+                    event:'bla',
+                    array: []
+                  },
+                  applyMappings: function () {}
+                };
+
+                store.addEvents([event], function(err) {
+                  expect(err).not.to.be.ok();
+
+                  store.getEvents({}, 0, -1, function(err, evts) {
+                    expect(err).not.to.be.ok();
+
+                    expect(evts[0].payload.array).to.be.an('array');
 
                     done();
                   });
@@ -195,7 +230,8 @@ types.forEach(function (type) {
                   restInCommitStream: 1,
                   payload: {
                     event:'bla'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 var event2 = {
@@ -208,7 +244,8 @@ types.forEach(function (type) {
                   restInCommitStream: 0,
                   payload: {
                     event:'bla2'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 store.addEvents([event1, event2], function(err) {
@@ -753,7 +790,8 @@ types.forEach(function (type) {
                   commitSequence: 0,
                   payload: {
                     event:'bla'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 store.addEvents([event], function(err) {
@@ -778,7 +816,8 @@ types.forEach(function (type) {
                   commitSequence: 0,
                   payload: {
                     event:'blaffff'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 store.addEvents([event], function(err) {
@@ -815,7 +854,8 @@ types.forEach(function (type) {
                   commitSequence: 0,
                   payload: {
                     event:'blaffff'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 store.addEvents([event], function(err) {
@@ -854,7 +894,8 @@ types.forEach(function (type) {
                   commitSequence: 0,
                   payload: {
                     event:'blaffff'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 store.addEvents([event], function(err) {
@@ -893,7 +934,8 @@ types.forEach(function (type) {
                   commitId: '118',
                   payload: {
                     event:'blaffff'
-                  }
+                  },
+                  applyMappings: function () {}
                 };
 
                 store.addEvents([event], function(err) {
@@ -932,7 +974,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla'
-              }
+              },
+              applyMappings: function () {}
             }, {
               aggregateId: 'id',
               streamRevision: 1,
@@ -942,7 +985,8 @@ types.forEach(function (type) {
               commitSequence: 1,
               payload: {
                 event:'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream2 = [{
@@ -955,7 +999,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla'
-              }
+              },
+              applyMappings: function () {}
             }, {
               aggregateId: 'idWithAgg',
               aggregate: 'myAgg',
@@ -966,7 +1011,8 @@ types.forEach(function (type) {
               commitSequence: 1,
               payload: {
                 event: 'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream3 = [{
@@ -979,7 +1025,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream4 = [{
@@ -992,7 +1039,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla'
-              }
+              },
+              applyMappings: function () {}
             }, {
               aggregateId: 'idWithCont',
               context: 'myCont',
@@ -1003,7 +1051,8 @@ types.forEach(function (type) {
               commitSequence: 1,
               payload: {
                 event: 'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream5 = [{
@@ -1016,7 +1065,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream6 = [{
@@ -1030,7 +1080,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla'
-              }
+              },
+              applyMappings: function () {}
             }, {
               aggregateId: 'idWithAggrAndCont',
               aggregate: 'myAggrrr',
@@ -1042,7 +1093,8 @@ types.forEach(function (type) {
               commitSequence: 1,
               payload: {
                 event: 'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream7 = [{
@@ -1056,7 +1108,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla'
-              }
+              },
+              applyMappings: function () {}
             }, {
               aggregateId: 'idWithAggrAndCont2',
               aggregate: 'myAggrrr2',
@@ -1068,7 +1121,8 @@ types.forEach(function (type) {
               commitSequence: 1,
               payload: {
                 event: 'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream8 = [{
@@ -1082,7 +1136,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream9 = [{
@@ -1096,7 +1151,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event: 'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var stream10 = [{
@@ -1110,7 +1166,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             var allEvents = [].concat(stream1).concat(stream2).concat(stream3)
@@ -2313,7 +2370,8 @@ types.forEach(function (type) {
               commitSequence: 0,
               payload: {
                 event:'bla'
-              }
+              },
+              applyMappings: function () {}
             }, {
               aggregateId: 'id',
               streamRevision: 1,
@@ -2323,7 +2381,8 @@ types.forEach(function (type) {
               commitSequence: 1,
               payload: {
                 event:'bla2'
-              }
+              },
+              applyMappings: function () {}
             }];
 
             beforeEach(function (done) {


### PR DESCRIPTION
The lua script has been removed, and the stream revision consistency is based on a redis `INCR`, which is enough to ensure that the revision is the right one.
It was also necessary to re apply mappings once the revision has been reset.

Fixes #96