### PR TITLE
Fixing dynamodb DocumentClient initialization

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -63,7 +63,7 @@ _.extend(DynamoDB.prototype, {
   connect: function (callback) {
     var self = this;
     self.client = new aws.DynamoDB(self.options.endpointConf);
-    self.documentClient = new aws.DynamoDB.DocumentClient(self.client);
+    self.documentClient = new aws.DynamoDB.DocumentClient({ service: self.client });
     self.isConnected = true;
 
     var createEventsTable = function (callback) {


### PR DESCRIPTION
Passing configuration values on initialization to the DynamoDB document client did not work since the DocumentClient constructor did not correctly receive the DynamoDB client as outlined in the SDK docs.
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#constructor-property

This should be fixed now with this commit, being able to pass the init values as part of the configuration rather than the global AWS config object (env variables).