### PR TITLE
Fix DynamoDB concurrency

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -685,7 +685,7 @@ _.extend(DynamoDB.prototype, {
 var StoredEvent = function (event) {
   debug("Converting event to StoredEvent: " + JSON.stringify(event, null, 2));
   this.aggregateId = event.aggregateId;
-  this.rowKey = new Date(event.commitStamp).toISOString() + ":" + (event.context || "") + ":" + (event.aggregate || "") + ":" + event.streamRevision;
+  this.rowKey = (event.context || "") + ":" + (event.aggregate || "") + ":" + event.streamRevision;
   this.id = event.id;
   this.context = event.context;
   this.aggregate = event.aggregate;


### PR DESCRIPTION
Currently the condition expression that is supposed to protect against concurrency violations will only be invoked when both commits are created using the exact same commit timestamp. This is because condition expressions are only checked against items with the same key. The fix for this is to remove the timestamp from the key, leaving the aggregateId, aggregate, context and streamRevision.