### PR TITLE
Fix sort key/range key ordering in dynamodb events table

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -687,7 +687,7 @@ _.extend(DynamoDB.prototype, {
 var StoredEvent = function (event) {
   debug("Converting event to StoredEvent: " + JSON.stringify(event, null, 2));
   this.aggregateId = event.aggregateId;
-  this.rowKey = (event.context || "") + ":" + (event.aggregate || "") + ":" + event.streamRevision;
+  this.rowKey = (event.context || "") + ":" + (event.aggregate || "") + ":" + _.padStart(event.streamRevision, 16, '0');
   this.id = event.id;
   this.context = event.context;
   this.aggregate = event.aggregate;


### PR DESCRIPTION
PR #110 correctly removed the commitStamp from the derived rowKey value in the dynamodb provider to resolve a concurrency issue, however it has also revealed an issue with the events table sort key/range key (provided by the derived "rowKey" value)

Queries/Scans against aggregates with more than 10 revisions are currently being returned with an incorrect sort order from the dynamodb events table due to the stream revision value not being padded.

e.g. (current)

| aggregateId  | rowKey |
| ------------- | ------------- |
| myagg1 | ::0 |
| myagg1 | ::1 |
| myagg1 | ::10 |
| myagg1 | ::2 |
| myagg1 | ::3 |
...
| myagg1 | ::9 |

e.g. (with fix by padding the stream revision value during rowKey derivation)

| aggregateId  | rowKey |
| ------------- | ------------- |
| myagg1 | ::000 |
| myagg1 | ::001 |
| myagg1 | ::002 |
| myagg1 | ::003 |
...
| myagg1 | ::009 |
| myagg1 | ::010 |

I have set the padding amount to 16 digits, which represents the number of digits in the [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) value.