### PR TITLE
events.next() is placed in the wrong scope

### DIFF
--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -123,16 +123,6 @@ _.extend(Eventstore.prototype, {
   getEvents: function (query, skip, limit, callback) {
     var self = this;
 
-    function nextFn(callback) {
-      if (limit < 0) {
-        var resEvts = [];
-        resEvts.next = nextFn;
-        return process.nextTick(function () { callback(null, resEvts) });
-      }
-      skip += limit;
-      _getEvents(query, skip, limit, callback);
-    }
-
     function _getEvents(query, skip, limit, callback) {
       if (typeof query === 'function') {
         callback = query;
@@ -159,6 +149,16 @@ _.extend(Eventstore.prototype, {
 
       if (typeof query === 'string') {
         query = { aggregateId: query };
+      }
+
+      function nextFn(callback) {
+        if (limit < 0) {
+          var resEvts = [];
+          resEvts.next = nextFn;
+          return process.nextTick(function () { callback(null, resEvts) });
+        }
+        skip += limit;
+        _getEvents(query, skip, limit, callback);
       }
 
       self.store.getEvents(query, skip, limit, function (err, evts) {

--- a/test/eventstoreTest.js
+++ b/test/eventstoreTest.js
@@ -1170,6 +1170,45 @@ describe('eventstore', function () {
 
               });
 
+              describe('requesting all existing events, without query argument and using next function', function () {
+
+                describe('and committing some new events', function () {
+
+                  it('it should work as expected', function (done) {
+
+                    es.getEvents(0, 3, function (err, evts) {
+                      expect(err).not.to.be.ok();
+
+                      expect(evts.length).to.eql(3);
+
+                      expect(evts.next).to.be.a('function');
+
+                      evts.next(function (err, nextEvts) {
+                        expect(err).not.to.be.ok();
+
+                        expect(nextEvts.length).to.eql(3);
+
+                        expect(nextEvts.next).to.be.a('function');
+
+                        nextEvts.next(function (err, nextNextEvts) {
+                          expect(err).not.to.be.ok();
+
+                          expect(nextNextEvts.length).to.eql(2);
+
+                          expect(nextNextEvts.next).to.be.a('function');
+
+                          done();
+                        });
+                      });
+
+                    });
+
+                  });
+
+                });
+
+              });
+
               describe('requesting existing events since a date and using next function', function () {
 
                 describe('and committing some new events', function () {


### PR DESCRIPTION
The bug fix to issue #112 left the events.next() function in the wrong scope. So if you call es.getEvents((err, events) => {...}) without query and/or skip, limit parameters the events.next() won't receive the parameter cleanup and behave in an unpredictable way.