### PR TITLE
Fix concurrency issue in createTableIfNotExists (DynamoDB adapter)

### DIFF
--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -810,11 +810,15 @@ function UndispatchedEventsTableDefinition(opts) {
   return def;
 }
 
+function isTableAlreadyExistsError (err) {
+  return err.code === "ResourceInUseException" && err.message === "Cannot create preexisting table"
+}
+
 var createTableIfNotExists = function (client, params, callback) {
   var exists = function (p, cbExists) {
     client.describeTable({ TableName: p.TableName }, function (err, data) {
       if (err) {
-        if (err.code === "ResourceNotFoundException") {
+        if (err.code === "ResourceNotFoundException" && !isTableAlreadyExistsError(err)) {
           debug("Table " + p.TableName + " doesn't exist yet: " + JSON.stringify(p, null, 2));
           cbExists(null, { exists: false, definition: p });
         } else {
@@ -836,8 +840,8 @@ var createTableIfNotExists = function (client, params, callback) {
           error("Error while creating " + r.definition.TableName + ": " + JSON.stringify(err, null, 2));
           cbCreate(err);
         } else {
-          debug(data.TableDescription.TableName + "created. Waiting for activiation.");
-          cbCreate(null, { Table: { TableName: data.TableDescription.TableName, TableStatus: data.TableDescription.TableStatus } });
+          debug(params.TableName + " created. Waiting for activiation.");
+          cbCreate(null, { Table: { TableName: data.TableDescription.TableName, TableStatus: data ? data.TableDescription.TableStatus : "UNKNOWN"} });
         }
       });
     } else {


### PR DESCRIPTION
During concurrent operations there is no guarantee that a table is not created between checking it's existance (using describeTable) and making the call to create the table. Currently, when this happens, it is erroring out with the 'Cannot create preexisting table' error.

Even ensuring that the init promise is resolved before calling it again is not enough because the call to describeTable is eventually consistent.

The fix is to swallow the error when the table already exists. At the end of the day, the system is in the state that we want it to be anyway (the table exists).