### PR TITLE
Fix store.cleanSnapshots for redis implementation

### DIFF
--- a/lib/databases/redis.js
+++ b/lib/databases/redis.js
@@ -589,9 +589,15 @@ _.extend(Redis.prototype, {
       var keysToDelete = keys
         .sort()
         .slice(0, -1 * self.options.maxSnapshotsCount)
-        .concat(callback);
 
-      self.client.del.apply(self.client, keysToDelete);
+      if (keysToDelete.length === 0) {
+        if (callback) callback(null, 0);
+        return;
+      }
+
+      var delArgs = keysToDelete.concat(callback);
+
+      self.client.del.apply(self.client, delArgs);
     });
   },
 

--- a/test/storeTest.js
+++ b/test/storeTest.js
@@ -3038,53 +3038,92 @@ types.forEach(function (type) {
                 }
               };
 
-              beforeEach(function (done) {
-                async.series([
-                  function (callback) {
-                    store.addSnapshot(snap1, callback);
-                  },
-                  function (callback) {
-                    store.addSnapshot(snap2, callback);
-                  },
-                  function (callback) {
-                    store.addSnapshot(snap3, callback);
-                  },
-                  function (callback) {
-                    store.addSnapshot(snap4, callback);
-                  },
-                  function (callback) {
-                    store.addSnapshot(snap5, callback);
-                  },
-                  function (callback) {
-                    store.addSnapshot(snap6, callback);
-                  },
-                  function (callback) {
-                    store.addSnapshot(snap7, callback);
-                  },
-                  function (callback) {
-                    store.addSnapshot(snap8, callback);
-                  }
-                ], done);
-              });
-
               describe('with an aggregateId being used only in one context and aggregate', function () {
 
-                it('it should clean oldest snapshots', function (done) {
+                describe('having fewer snapshots than the threshold', function() {
 
-                  store.cleanSnapshots({
-                    aggregateId: '920193847',
-                    aggregate: 'myCoolAggregate',
-                    context: 'myCoolContext'
-                  }, function (err, cleanedCount) {
-                    expect(err).not.to.be.ok();
-                    expect(cleanedCount).to.equal(3);
-                    done();
+                  beforeEach(function (done) {
+                    async.series([
+                      function (callback) {
+                        store.addSnapshot(snap1, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap2, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap3, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap4, callback);
+                      }
+                    ], done);
+                  });
+
+                  it('can be called without error', function(done) {
+
+                    store.cleanSnapshots({
+                      aggregateId: '920193847',
+                      aggregate: 'myCoolAggregate',
+                      context: 'myCoolContext'
+                    }, function (err, cleanedCount) {
+                      expect(err).not.to.be.ok();
+                      expect(cleanedCount).to.equal(0);
+                      done();
+                    });
+
+                  })
+                })
+
+                describe('having more snapshots than the threshold', function() {
+
+                  beforeEach(function (done) {
+                    async.series([
+                      function (callback) {
+                        store.addSnapshot(snap1, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap2, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap3, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap4, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap5, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap6, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap7, callback);
+                      },
+                      function (callback) {
+                        store.addSnapshot(snap8, callback);
+                      }
+                    ], done);
+                  });
+
+                  it('it should clean oldest snapshots', function (done) {
+
+                    store.cleanSnapshots({
+                      aggregateId: '920193847',
+                      aggregate: 'myCoolAggregate',
+                      context: 'myCoolContext'
+                    }, function (err, cleanedCount) {
+                      expect(err).not.to.be.ok();
+                      expect(cleanedCount).to.equal(3);
+                      done();
+                    });
+
                   });
 
                 });
+
               });
 
-            });
+            })
 
           });
 


### PR DESCRIPTION
### Before
If you have an `EventStore` instance of type `redis` including a non-zero `maxSnapshotsCount` (for example, `maxSnapshotsCount: 5`),
When you have fewer than 5 snapshots (i.e. 0), and you call something like:

```js
es.createSnapshot(snap, (err) => {
    if (err) { console.log(err); /*handle err*/ }
    // ...etc.
})
```

Then you will see this error:
```
ReplyError: ERR wrong number of arguments for 'del' command
/app/node_modules/redis-parser/lib/parser.js in parseError at line 193:12
```

(NOTE: the snapshot *does* get created correctly, but then the return value errors because `cleanSnapshots` fails).

### Now

You can call `es.createSnapshot(snap, cb)` without the error from `cleanSnapshots`.


@adrai hope this is helpful, and let me know if you see any changes you'd like made. Thanks.

(Fixes #126)