### PR TITLE
Generate new event id rather than deriving it

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -263,18 +263,18 @@ _.extend(Mongo.prototype, {
     var self = this;
     async.parallel([
       function (callback) {
-        self.events.remove({}, callback);
+        self.events.deleteOne({}, callback);
       },
       function (callback) {
-        self.snapshots.remove({}, callback);
+        self.snapshots.deleteOne({}, callback);
       },
       function (callback) {
-        self.transactions.remove({}, callback);
+        self.transactions.deleteOne({}, callback);
       },
       function (callback) {
         if (!self.positions)
           return callback(null);
-        self.positions.remove({}, callback);
+        self.positions.deleteOne({}, callback);
       }
     ], function (err) {
       if (err) {
@@ -351,7 +351,7 @@ _.extend(Mongo.prototype, {
       }
 
       if (events.length === 1) {
-        return self.events.insert(events, callback);
+        return self.events.insertOne(events[0], callback);
       }
 
       var tx = {
@@ -362,14 +362,14 @@ _.extend(Mongo.prototype, {
         context: events[0].context
       };
 
-      self.transactions.insert(tx, function (err) {
+      self.transactions.insertOne(tx, function (err) {
         if (err) {
           debug(err);
           if (callback) callback(err);
           return;
         }
 
-        self.events.insert(events, function (err) {
+        self.events.insertMany(events, function (err) {
           if (err) {
             debug(err);
             if (callback) callback(err);
@@ -546,7 +546,7 @@ _.extend(Mongo.prototype, {
 
   setEventToDispatched: function (id, callback) {
     var updateCommand = { '$unset' : { 'dispatched': null } };
-    this.events.update({'_id' : id}, updateCommand, callback);
+    this.events.updateOne({'_id' : id}, updateCommand, callback);
   },
 
   addSnapshot: function(snap, callback) {
@@ -558,7 +558,7 @@ _.extend(Mongo.prototype, {
     }
 
     snap._id = snap.id;
-    this.snapshots.insert(snap, callback);
+    this.snapshots.insertOne(snap, callback);
   },
 
   cleanSnapshots: function (query, callback) {
@@ -634,7 +634,7 @@ _.extend(Mongo.prototype, {
     }
 
     // the following is usually unnecessary
-    this.transactions.remove(findStatement, function (err) {
+    this.transactions.deleteMany(findStatement, function (err) {
       if (err) {
         debug(err);
       }
@@ -677,7 +677,7 @@ _.extend(Mongo.prototype, {
             return clb(null);
           }
           
-          self.transactions.remove({ _id: tx._id }, clb);
+          self.transactions.deleteOne({ _id: tx._id }, clb);
         });
       }, function (err) {
         if (err) {
@@ -742,7 +742,7 @@ _.extend(Mongo.prototype, {
 
       var missingEvts = tx.events.slice(tx.events.length - lastEvt.restInCommitStream);
 
-      self.events.insert(missingEvts, function (err) {
+      self.events.insertMany(missingEvts, function (err) {
         if (err) {
           debug(err);
           return callback(err);

--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -493,8 +493,12 @@ _.extend(Eventstore.prototype, {
             return callback(err)
 
           for (var i = 0, len = uncommittedEvents.length; i < len; i++) {
+            var evtId;
+            self.getNewId(function (_, generated) {
+              evtId = generated;
+            });
             event = uncommittedEvents[i];
-            event.id = id + i.toString();
+            event.id = evtId;
             event.commitId = id;
             event.commitSequence = i;
             event.restInCommitStream = len - 1 - i;


### PR DESCRIPTION
When writing event documents to the underlying store, the ID should be a consistent known format, rather than derived from the commit id plus the commit sequence. From a data store perspectives, if someone is using UUIDs, they expect UUIDs everywhere. Or if it's mongo ObjectIds, they should be consistent. I don't see any other code that assumes that the event id is derived. Of course if consumers are making this assumption, this would be a breaking change.