### PR TITLE
Update mongo methods to non-deprecated versions

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -263,18 +263,18 @@ _.extend(Mongo.prototype, {
     var self = this;
     async.parallel([
       function (callback) {
-        self.events.remove({}, callback);
+        self.events.deleteOne({}, callback);
       },
       function (callback) {
-        self.snapshots.remove({}, callback);
+        self.snapshots.deleteOne({}, callback);
       },
       function (callback) {
-        self.transactions.remove({}, callback);
+        self.transactions.deleteOne({}, callback);
       },
       function (callback) {
         if (!self.positions)
           return callback(null);
-        self.positions.remove({}, callback);
+        self.positions.deleteOne({}, callback);
       }
     ], function (err) {
       if (err) {
@@ -351,7 +351,7 @@ _.extend(Mongo.prototype, {
       }
 
       if (events.length === 1) {
-        return self.events.insert(events, callback);
+        return self.events.insertOne(events[0], callback);
       }
 
       var tx = {
@@ -362,14 +362,14 @@ _.extend(Mongo.prototype, {
         context: events[0].context
       };
 
-      self.transactions.insert(tx, function (err) {
+      self.transactions.insertOne(tx, function (err) {
         if (err) {
           debug(err);
           if (callback) callback(err);
           return;
         }
 
-        self.events.insert(events, function (err) {
+        self.events.insertMany(events, function (err) {
           if (err) {
             debug(err);
             if (callback) callback(err);
@@ -546,7 +546,7 @@ _.extend(Mongo.prototype, {
 
   setEventToDispatched: function (id, callback) {
     var updateCommand = { '$unset' : { 'dispatched': null } };
-    this.events.update({'_id' : id}, updateCommand, callback);
+    this.events.updateOne({'_id' : id}, updateCommand, callback);
   },
 
   addSnapshot: function(snap, callback) {
@@ -558,7 +558,7 @@ _.extend(Mongo.prototype, {
     }
 
     snap._id = snap.id;
-    this.snapshots.insert(snap, callback);
+    this.snapshots.insertOne(snap, callback);
   },
 
   cleanSnapshots: function (query, callback) {
@@ -634,7 +634,7 @@ _.extend(Mongo.prototype, {
     }
 
     // the following is usually unnecessary
-    this.transactions.remove(findStatement, function (err) {
+    this.transactions.deleteMany(findStatement, function (err) {
       if (err) {
         debug(err);
       }
@@ -677,7 +677,7 @@ _.extend(Mongo.prototype, {
             return clb(null);
           }
           
-          self.transactions.remove({ _id: tx._id }, clb);
+          self.transactions.deleteOne({ _id: tx._id }, clb);
         });
       }, function (err) {
         if (err) {
@@ -742,7 +742,7 @@ _.extend(Mongo.prototype, {
 
       var missingEvts = tx.events.slice(tx.events.length - lastEvt.restInCommitStream);
 
-      self.events.insert(missingEvts, function (err) {
+      self.events.insertMany(missingEvts, function (err) {
         if (err) {
           debug(err);
           return callback(err);


### PR DESCRIPTION
The remove, insert, and update methods have been deprecated.  The latest version of mongo has new method names (as of at the latest April 2015, see commit at https://github.com/mongodb/node-mongodb-native/commit/9e96e9de0ac50fb6e64f6f9cc2f83559ac7f5fb6).