### PR TITLE
feat: add retry function for dynamodb putItem in addEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ var es = require('eventstore')({
     useUndispatchedEventsTable: true            // optional
     eventsTableStreamEnabled: false             // optional
     eventsTableStreamViewType: 'NEW_IMAGE',     // optional
-    emitStoreEvents: true                       // optional, by default no store events are emitted
+    emitStoreEvents: true,                      // optional, by default no store events are emitted
+    maxAddEventsRetryCount: 0                   // optional, number. retry times if putItem failed. 0 means do not retry
 });
 ```
 

--- a/lib/databases/dynamodb.js
+++ b/lib/databases/dynamodb.js
@@ -50,7 +50,8 @@ function DynamoDB(options) {
     SnapshotWriteCapacityUnits: 1,
     useUndispatchedEventsTable: true,
     eventsTableStreamEnabled: false,
-    eventsTableStreamViewType: "NEW_IMAGE"
+    eventsTableStreamViewType: "NEW_IMAGE",
+    maxAddEventsRetryCount: 0
   };
 
   this.options = _.defaults(this.options, defaults);
@@ -182,7 +183,11 @@ _.extend(DynamoDB.prototype, {
             };
 
             debug("Saving event to events table: " + JSON.stringify(storedEvent, null, 2));
-            self.documentClient.put(storedEvent, function (err, data) {
+            function saveEvent (cb) {
+              self.documentClient.put(storedEvent, cb);
+            }
+
+            function savedCallback (err, data) {
               if (err) {
                 error("dynamodb.addEvents error: " + JSON.stringify(err));
                 return callback(err);
@@ -190,7 +195,40 @@ _.extend(DynamoDB.prototype, {
                 debug("event saved");
                 callback(null, data);
               }
-            });
+            }
+
+            function retrySaveEvent () {
+              var maxAddEventsRetryCount = self.options.maxAddEventsRetryCount;
+
+              if (!maxAddEventsRetryCount) {
+                saveEvent(savedCallback);
+                return;
+              }
+
+              var retryCount = retryCount || 0;
+
+              function _retry() {
+                saveEvent(function(err, data) {
+                  if (!err) {
+                    savedCallback(null, data);
+                  } else {
+                    if (retryCount === maxAddEventsRetryCount) {
+                      error("retry failed: " + retryCount + " times");
+                      savedCallback(err, data);
+                    } else {
+                      debug("dynamodb.addEvents error: " + JSON.stringify(err) + " . Retry...");
+                      retryCount++;
+                      var delay = 50 * Math.pow(2, retryCount - 1);
+                      setTimeout(_retry, delay);
+                    }
+                  }
+                });
+              }
+
+              _retry();
+            }
+
+            retrySaveEvent();
           }];
 
         if (self.options.useUndispatchedEventsTable) {


### PR DESCRIPTION
 add new dynamodb option: maxAddEventsRetryCount and retry putItem base on the retryCount number